### PR TITLE
Toggle registrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ jobs:
 
       - name: Authenticate with GitHub Packages on Windows
         # You may also reference the major or major.minor version
-        uses: im-open/authenticate-with-gh-package-registries@v1.0.6
+        uses: im-open/authenticate-with-gh-package-registries@v1.0.7
         with:
           read-pkg-token: ${{ secrets.READ_PKG_TOKEN }} # Token has read:packages scope and is authorized for each of the orgs
           orgs: 'myorg2,myorg2,octocoder'

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The PAT needs to have the `read:packages` scope, it should be authorized for eac
 | `read-pkg-token` | true        | N/A                                                                                          | A personal access token with the `read:packages` scope that has been authorized for use with each provided org and is from an account that has read access to the repo containing the package. |
 | `orgs`           | true        | `im-client,im-customer-engagement,im-enrollment,im-funding,im-platform,im-practices,bc-swat` | A comma-separated list of organizations that registry entries should be added for.                                                                                                             |
 | `set-nuget`      | true        | `true` | Set nuget registration. | |
-| `orgs`           | true        | `true` | Set npm registration.   | |
+| `set-npm`        | true        | `true` | Set npm registration.   | |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -79,10 +79,12 @@ The PAT needs to have the `read:packages` scope, it should be authorized for eac
 
 ## Inputs
 
-| Parameter        | Is Required | Default                                                                                    | Description                                                                                                                                                                                    |
-| ---------------- | ----------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
-| `read-pkg-token` | true        | N/A                                                                                        | A personal access token with the `read:packages` scope that has been authorized for use with each provided org and is from an account that has read access to the repo containing the package. |
-| `orgs`           | true        | im-client,im-customer-engagement,im-enrollment,im-funding,im-platform,im-practices,bc-swat | A comma-separated list of organizations that registry entries should be added for.                                                                                                             |     |
+| Parameter        | Is Required | Default                                                                                      | Description                                                                                                                                                                                    |
+| ---------------- | ----------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `read-pkg-token` | true        | N/A                                                                                          | A personal access token with the `read:packages` scope that has been authorized for use with each provided org and is from an account that has read access to the repo containing the package. |
+| `orgs`           | true        | `im-client,im-customer-engagement,im-enrollment,im-funding,im-platform,im-practices,bc-swat` | A comma-separated list of organizations that registry entries should be added for.                                                                                                             |
+| `set-nuget`      | true        | `true` | Set nuget registration. | |
+| `orgs`           | true        | `true` | Set npm registration.   | |
 
 ## Outputs
 
@@ -105,7 +107,7 @@ jobs:
 
       - name: Authenticate with GitHub Packages on Windows
         # You may also reference the major or major.minor version
-        uses: im-open/authenticate-with-gh-package-registries@v1.0.7
+        uses: im-open/authenticate-with-gh-package-registries@v1.0.6
         with:
           read-pkg-token: ${{ secrets.READ_PKG_TOKEN }} # Token has read:packages scope and is authorized for each of the orgs
           orgs: 'myorg2,myorg2,octocoder'

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ jobs:
 
       - name: Authenticate with GitHub Packages on Windows
         # You may also reference the major or major.minor version
-        uses: im-open/authenticate-with-gh-package-registries@v1.0.6
+        uses: im-open/authenticate-with-gh-package-registries@v1.0.7
         with:
           read-pkg-token: ${{ secrets.READ_PKG_TOKEN }} # Token has read:packages scope and is authorized for each of the orgs
           orgs: 'myorg2,myorg2,octocoder'

--- a/action.yml
+++ b/action.yml
@@ -10,17 +10,27 @@ inputs:
     description: 'A comma-separated list of organizations that package sources should be added for.'
     required: true
     default: 'im-client,im-customer-engagement,im-enrollment,im-funding,im-platform,im-practices,bc-swat'
+  set-nuget:
+    description: 'Add registries for nuget'
+    required: true
+    default: 'true'
+  set-npm:
+    description: 'Add registries for npm'
+    required: true
+    default: 'true'
 
 runs:
   using: 'composite'
   steps:
     # Nuget **********************
     - name: nuget - add soures
+      if: inputs.set-nuget == 'true'
       shell: pwsh
       run: ${{ github.action_path }}/nuget.ps1 -rawOrgs "${{ inputs.orgs }}" -runnerOs "${{ runner.os }}"
 
     # NPM ************************
     - name: npm - delete existing authToken
+      if: inputs.set-npm == 'true'
       shell: pwsh
       run: npm config delete //npm.pkg.github.com/:_authToken
       env:
@@ -30,6 +40,7 @@ runs:
         GITHUB_TOKEN: 'placeholder'
 
     - name: npm - add registries
+      if: inputs.set-npm == 'true'
       shell: pwsh
       run: ${{ github.action_path }}/npm.ps1 -rawOrgs "${{ inputs.orgs }}" -runnerOs "${{ runner.os }}"
 


### PR DESCRIPTION
# Summary of PR changes

When we only need to register access to NPM packages, the action currently requires the runner have `dotnet`.

Add ability to toggle off `nuget` package registration.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
