### PR TITLE
DEVO-2828: make legacy variables optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ jobs:
 
       - name: Authenticate with GitHub Packages on Windows
         # You may also reference the major or major.minor version
-        uses: im-open/authenticate-with-gh-package-registries@v2.0.0
+        uses: im-open/authenticate-with-gh-package-registries@v2.0.1
         with:
           read-pkg-token: ${{ secrets.READ_PKG_TOKEN }} # Token has read:packages scope and is authorized for each of the orgs
           orgs: 'myorg2,myorg2,octocoder'
@@ -148,7 +148,7 @@ jobs:
 
       - name: Authenticate with GitHub Packages on Windows
         # You may also reference the major or major.minor version
-        uses: im-open/authenticate-with-gh-package-registries@v2.0.0
+        uses: im-open/authenticate-with-gh-package-registries@v2.0.1
         with:
           read-pkg-token: ${{ secrets.READ_PKG_TOKEN }} # Token has read:packages scope and is authorized for each of the orgs
           read-pkg-token-legacy: ${{ secrets.READ_PKG_TOKEN_LEGACY }} # Token has read:packages scope and is authorized for each of the orgs

--- a/action.yml
+++ b/action.yml
@@ -8,15 +8,16 @@ inputs:
     required: true
   read-pkg-token-legacy:
     description: 'A legacy organization personal access token with the read:packages scope that has been authorized for use with each provided org and is from an account that has read access to the repo containing the package.'
-    required: true
+    required: false
+    default: ''
   orgs:
     description: 'A comma-separated list of organizations that package sources should be added for.'
     required: true
     default: 'wtw-bdoim'
   orgs-legacy:
     description: 'A comma-separated list of legacy organizations that package sources should be added for.'
-    required: true
-    default: 'im-client,im-customer-engagement,im-enrollment,im-funding,im-platform,im-practices,bc-swat'
+    required: false
+    default: ''
   setup-nuget:
     description: 'Flag indicating whether to set each org as a nuget source.'
     required: false

--- a/npm.ps1
+++ b/npm.ps1
@@ -1,7 +1,7 @@
 Param(
     [parameter(Mandatory = $true)]
     [string]$rawOrgs,
-    [parameter(Mandatory = $true)]
+    [parameter(Mandatory = $false)]
     [string]$rawOrgsLegacy,
     [parameter(Mandatory = $true)]
     [string]$runnerOs
@@ -10,7 +10,6 @@ Param(
 Write-Host "Adding registries to a $runnerOs machine"
 $orgList = $rawOrgs.Split(',');
 $orgListLegacy = $rawOrgsLegacy.Split(',');
-
 
 foreach ($org in $orgList)
 {

--- a/npm.ps1
+++ b/npm.ps1
@@ -15,19 +15,29 @@ $orgListLegacy = $rawOrgsLegacy.Split(',');
 foreach ($org in $orgList)
 {
     $org = $org.Trim();
+    if ([string]::IsNullOrWhiteSpace($org)) { continue }
     $registry = ":registry"
+    $authToken = ":_authToken"
     Write-Host "Adding the $org$registry registry entry..."
     npm config delete "@$org$registry" 
     npm config set "@$org$registry" https://npm.pkg.github.com
+    Write-Host "Adding the $org$authToken auth token entry..."
+    npm config delete "@$org$authToken"
+    npm config set "@$org$authToken" '${READ_PACKAGE_TOKEN}'
 }
 
 foreach ($org in $orgListLegacy)
 {
     $org = $org.Trim();
+    if ([string]::IsNullOrWhiteSpace($org)) { continue }
     $registry = ":registry"
+    $authToken = ":_authToken"
     Write-Host "Adding the $org$registry registry entry..."
     npm config delete "@$org$registry" 
     npm config set "@$org$registry" https://npm.pkg.github.com
+    Write-Host "Adding the $org$authToken auth token entry..."
+    npm config delete "@$org$authToken"
+    npm config set "@$org$authToken" '${READ_PACKAGE_TOKEN_LEGACY}'
 }
 
 # This sets the _authToken for github packages to the literal value: ${READ_PACKAGE_TOKEN}

--- a/nuget.ps1
+++ b/nuget.ps1
@@ -34,6 +34,7 @@ else
 foreach ($org in $orgList)
 {
     $org = $org.Trim();
+    if ([string]::IsNullOrWhiteSpace($org)) { continue }
     Write-Host "`nChecking $org..."
     if ($sources.Contains($org)) 
     {
@@ -52,6 +53,7 @@ foreach ($org in $orgList)
 foreach ($org in $orgListLegacy)
 {
     $org = $org.Trim();
+    if ([string]::IsNullOrWhiteSpace($org)) { continue }
     Write-Host "`nChecking $org..."
     if ($sources.Contains($org)) 
     {
@@ -65,6 +67,12 @@ foreach ($org in $orgListLegacy)
     
     Write-Host "Adding the $org source..."
     dotnet nuget add source https://nuget.pkg.github.com/$org/index.json --name $org --username USERNAME --password %READ_PACKAGE_TOKEN_LEGACY% --store-password-in-clear-text
+}
+
+if ($null -eq $nugetPackageSourceMappingPattern)
+{
+    Write-Host "No nuget package source mapping pattern provided, skipping adding package source mapping"
+    exit 0 # Stop the script here since we don't want to add package source mapping if no pattern is provided
 }
 
 . "$PSScriptRoot\nuget-add-package-source-mapping.ps1"


### PR DESCRIPTION
# Summary of PR changes
 Update action inputs to make legacy tokens optional and improve handling of empty organization names in scripts.


## PR Requirements
- [ ] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [ ] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
